### PR TITLE
Name the outbound webhook for what it is, not for one receiver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,6 +133,11 @@ ROMM_USERNAME=your_romm_username
 ROMM_PASSWORD=your_romm_password
 
 # n8n Workflow Automation (optional)
+# Outbound webhook for request events. Any receiver that accepts JSON works --
+# n8n, a download automation service, a script, a chat bridge.
+# REQUEST_WEBHOOK_URL=https://automation.yourdomain.com/hook/game-request
+#
+# Deprecated alias, still honoured so existing installs keep working:
 # N8N_WEBHOOK_URL=https://n8n.yourdomain.com/webhook/game-request
 
 # =================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
       ROMM_USERNAME: ${ROMM_USERNAME:-}
       ROMM_PASSWORD: ${ROMM_PASSWORD:-}
       N8N_WEBHOOK_URL: ${N8N_WEBHOOK_URL:-}
+      REQUEST_WEBHOOK_URL: ${REQUEST_WEBHOOK_URL:-}
 
       # Application Configuration
       PM2_INSTANCES: ${PM2_INSTANCES:-max}

--- a/docs/guides/INTEGRATIONS.md
+++ b/docs/guides/INTEGRATIONS.md
@@ -131,16 +131,44 @@ Both are required; notifications are skipped if either is missing. Create an
 
 ---
 
-## n8n
+## Outbound request webhook
 
-Posts request events to an n8n webhook for workflow automation.
+Posts request events to any URL that accepts JSON. n8n is one receiver; so is a
+download automation service, a script, or a chat bridge.
 
 ```env
-N8N_WEBHOOK_URL=https://n8n.example.com/webhook/ggrequestz
+REQUEST_WEBHOOK_URL=https://automation.example.com/hook/ggrequestz
 ```
+
+`N8N_WEBHOOK_URL` is still honoured as a deprecated alias, so existing installs
+need no change. When both are set, `REQUEST_WEBHOOK_URL` wins.
 
 The app sends its own outbound webhooks from `/api/webhooks`; failures are
 logged and do not block the request that triggered them.
+
+### Payload
+
+```json
+{
+  "type": "game_request",
+  "title": "New Game Request: Chrono Trigger",
+  "message": "alice requested \"Chrono Trigger\"",
+  "priority": 5,
+  "timestamp": "2026-01-01T00:00:00.000Z",
+  "data": {
+    "request_id": 42,
+    "user_id": 7,
+    "game_title": "Chrono Trigger",
+    "igdb_id": 1234,
+    "platforms": ["Super Nintendo"],
+    "request_type": "game"
+  }
+}
+```
+
+`data.game_title` and `data.platforms` are what a receiver needs to act on a
+request. `igdb_id` identifies the title unambiguously where the receiver also
+speaks IGDB.
 
 ---
 

--- a/src/routes/api/webhooks/+server.js
+++ b/src/routes/api/webhooks/+server.js
@@ -133,16 +133,13 @@ function requestWebhookUrl() {
  * Send the outbound request webhook.
  */
 async function sendRequestWebhook(payload) {
-  const response = await fetch(
-    requestWebhookUrl(),
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(payload),
+  const response = await fetch(requestWebhookUrl(), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
     },
-  );
+    body: JSON.stringify(payload),
+  });
 
   if (!response.ok) {
     throw new Error(`Request webhook error: ${response.statusText}`);

--- a/src/routes/api/webhooks/+server.js
+++ b/src/routes/api/webhooks/+server.js
@@ -1,5 +1,5 @@
 /**
- * Webhook endpoint for Gotify notifications and n8n automation
+ * Webhook endpoint for Gotify notifications and the outbound request webhook.
  */
 
 import { json, error } from "@sveltejs/kit";
@@ -47,10 +47,16 @@ export async function POST({ request }) {
       }
     }
 
-    // Send n8n webhook
-    if (env.N8N_WEBHOOK_URL || process.env.N8N_WEBHOOK_URL) {
+    // Send the outbound request webhook.
+    //
+    // The payload has always been provider-neutral JSON, but both the variable
+    // and the docs named n8n, so it reads as an n8n-only feature. The same
+    // dispatch under a neutral name lets any receiver subscribe -- a download
+    // automation service, a script, a chat bridge -- without pretending to be
+    // n8n.
+    if (requestWebhookUrl()) {
       try {
-        const n8nResponse = await sendN8nWebhook({
+        const n8nResponse = await sendRequestWebhook({
           type,
           title,
           message,
@@ -60,7 +66,7 @@ export async function POST({ request }) {
         });
         results.n8n = n8nResponse;
       } catch (n8nError) {
-        console.error("n8n webhook failed:", n8nError);
+        console.error("Request webhook failed:", n8nError);
         results.n8n = { error: n8nError.message };
       }
     }
@@ -109,11 +115,26 @@ async function sendGotifyNotification({ title, message, priority, extras }) {
 }
 
 /**
- * Send webhook to n8n
+ * The configured outbound webhook URL.
+ *
+ * REQUEST_WEBHOOK_URL is preferred; N8N_WEBHOOK_URL keeps working so existing
+ * installs need no change.
  */
-async function sendN8nWebhook(payload) {
+function requestWebhookUrl() {
+  return (
+    env.REQUEST_WEBHOOK_URL ||
+    process.env.REQUEST_WEBHOOK_URL ||
+    env.N8N_WEBHOOK_URL ||
+    process.env.N8N_WEBHOOK_URL
+  );
+}
+
+/**
+ * Send the outbound request webhook.
+ */
+async function sendRequestWebhook(payload) {
   const response = await fetch(
-    env.N8N_WEBHOOK_URL || process.env.N8N_WEBHOOK_URL,
+    requestWebhookUrl(),
     {
       method: "POST",
       headers: {
@@ -124,10 +145,10 @@ async function sendN8nWebhook(payload) {
   );
 
   if (!response.ok) {
-    throw new Error(`n8n webhook error: ${response.statusText}`);
+    throw new Error(`Request webhook error: ${response.statusText}`);
   }
 
-  // n8n might return different response formats
+  // Receivers return whatever they like; a non-JSON body is still a success.
   try {
     return await response.json();
   } catch {


### PR DESCRIPTION
## What

Adds `REQUEST_WEBHOOK_URL` as the documented name for the outbound webhook that `/api/webhooks` already sends, and documents the payload.

`N8N_WEBHOOK_URL` continues to work unchanged as an alias. When both are set, `REQUEST_WEBHOOK_URL` wins.

## Why

The payload has always been provider-neutral JSON, and any service that accepts JSON can consume it. But both the variable and the integrations guide say n8n, so it reads as an n8n-only feature — anyone wanting to drive something else from a request has no reason to think this already does it.

I hit exactly that: I was looking for a way to forward requests to a download automation service, concluded nothing existed, and only found this by reading `+server.js`. The capability was already there; the naming hid it.

## Changes

- `src/routes/api/webhooks/+server.js` — resolve the URL through a small `requestWebhookUrl()` helper preferring the new name; rename the internal sender and its error strings to match
- `.env.example` — document the new name, mark the old one deprecated
- `docs/guides/INTEGRATIONS.md` — retitle the section, document the payload and note which fields a receiver acts on

## Compatibility

No behaviour change for anyone already configured. An install setting only `N8N_WEBHOOK_URL` behaves exactly as before.

## Testing

Verified the resolution order across all six combinations (neither set, each set alone via `env` and `process.env`, both set):

| config | resolves to |
|---|---|
| neither | no dispatch |
| `N8N_WEBHOOK_URL` only | that URL — existing installs unaffected |
| `REQUEST_WEBHOOK_URL` only | that URL |
| both | `REQUEST_WEBHOOK_URL` |

Happy to adjust the naming if you'd prefer something else — `OUTBOUND_WEBHOOK_URL`, `WEBHOOK_URL`, or keeping n8n as primary with the generic name as the alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)