### PR TITLE
Dispatch the request webhook on submission

### DIFF
--- a/docs/guides/INTEGRATIONS.md
+++ b/docs/guides/INTEGRATIONS.md
@@ -143,8 +143,10 @@ REQUEST_WEBHOOK_URL=https://automation.example.com/hook/ggrequestz
 `N8N_WEBHOOK_URL` is still honoured as a deprecated alias, so existing installs
 need no change. When both are set, `REQUEST_WEBHOOK_URL` wins.
 
-The app sends its own outbound webhooks from `/api/webhooks`; failures are
-logged and do not block the request that triggered them.
+Submitting a request dispatches one. Failures are logged and never block the
+submission — by the time the webhook is sent the request is already saved, so a
+receiver that is slow, rejecting or absent cannot cost a user their request.
+Receivers get five seconds to respond.
 
 ### Payload
 
@@ -156,10 +158,10 @@ logged and do not block the request that triggered them.
   "priority": 5,
   "timestamp": "2026-01-01T00:00:00.000Z",
   "data": {
-    "request_id": 42,
-    "user_id": 7,
+    "request_id": "eac1cd44-5f6e-4f49-8ac1-9936066105a6",
+    "user_id": "12",
     "game_title": "Chrono Trigger",
-    "igdb_id": 1234,
+    "igdb_id": "1234",
     "platforms": ["Super Nintendo"],
     "request_type": "game"
   }
@@ -169,6 +171,13 @@ logged and do not block the request that triggered them.
 `data.game_title` and `data.platforms` are what a receiver needs to act on a
 request. `igdb_id` identifies the title unambiguously where the receiver also
 speaks IGDB.
+
+`request_id` is a UUID; `user_id` and `igdb_id` are strings, matching how they
+are stored. `platforms` is always an array, empty when the requester named no
+platform. `request_type` is `game`, `update` or `fix`.
+
+`priority` maps the request's own priority onto a 1-10 scale: `low` 3,
+`medium` 5, `high` 8, `urgent` 9.
 
 ---
 

--- a/src/lib/webhooks.js
+++ b/src/lib/webhooks.js
@@ -1,9 +1,18 @@
 /**
  * Webhook utility functions for notifications
+ *
+ * Browser-side helpers. Both post to the relative URL "/api/webhooks", so they
+ * only work from a component -- calling either from a server route silently
+ * targets nothing. Server-side callers want $lib/webhooks.server.js, which
+ * dispatches to the configured receiver directly.
  */
 
 /**
  * Send game request notification via webhook
+ *
+ * Not used by request submission: POST /api/request dispatches through
+ * $lib/webhooks.server.js instead, so the webhook fires whether the request
+ * arrived from the UI or from the API.
  */
 export async function sendGameRequestNotification(requestData) {
   return await fetch("/api/webhooks", {

--- a/src/lib/webhooks.server.js
+++ b/src/lib/webhooks.server.js
@@ -1,0 +1,117 @@
+/**
+ * The outbound request webhook, server side.
+ *
+ * `$lib/webhooks.js` describes the same payload, but posts to the relative URL
+ * "/api/webhooks", which only resolves in a browser. That made it unusable from
+ * an endpoint, and in practice nothing imported it -- so a submitted request
+ * notified Gotify and no configured receiver ever heard about it.
+ *
+ * Dispatching from here follows the same shape as the Gotify call beside it in
+ * `/api/request`: the route calls the sender directly rather than posting to our
+ * own HTTP endpoint. `/api/webhooks` shares these functions so both paths emit
+ * a byte-identical payload and a receiver need not care which produced it.
+ */
+
+import { env } from "$env/dynamic/private";
+
+// A receiver that is slow must not hold a user's request open. By the time this
+// runs the request is already committed; the webhook is a courtesy.
+const WEBHOOK_TIMEOUT_MS = 5000;
+
+// The 1-10 scale the payload has always used. `urgent` previously fell through
+// to the medium value, ranking it below `high` -- the one ordering a receiver is
+// likely to act on.
+const WEBHOOK_PRIORITIES = {
+  urgent: 9,
+  high: 8,
+  medium: 5,
+  low: 3,
+};
+const DEFAULT_WEBHOOK_PRIORITY = WEBHOOK_PRIORITIES.medium;
+
+/**
+ * The configured outbound webhook URL.
+ *
+ * REQUEST_WEBHOOK_URL is preferred; N8N_WEBHOOK_URL keeps working so existing
+ * installs need no change.
+ * @returns {string} - The URL, or "" when the webhook is not configured
+ */
+export function requestWebhookUrl() {
+  return (
+    env.REQUEST_WEBHOOK_URL ||
+    process.env.REQUEST_WEBHOOK_URL ||
+    env.N8N_WEBHOOK_URL ||
+    process.env.N8N_WEBHOOK_URL ||
+    ""
+  );
+}
+
+/**
+ * Post a payload to the configured receiver.
+ * @param {Object} payload - The webhook payload
+ * @returns {Promise<Object>} - The receiver's response, or a status summary
+ */
+export async function sendRequestWebhook(payload) {
+  const response = await fetch(requestWebhookUrl(), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Request webhook error: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  // Receivers return whatever they like; a non-JSON body is still a success.
+  try {
+    return await response.json();
+  } catch {
+    return { status: "sent", statusCode: response.status };
+  }
+}
+
+/**
+ * Announce a newly created game request.
+ *
+ * Takes the `ggr_game_requests` row as inserted, so the payload carries the
+ * stored values rather than the submitted ones.
+ * @param {Object} request - The inserted ggr_game_requests row
+ * @returns {Promise<boolean>} - Whether a webhook was dispatched
+ */
+export async function sendGameRequestWebhook(request) {
+  if (!requestWebhookUrl()) return false;
+
+  // JSONB comes back parsed, so this is normally already an array. Tolerate a
+  // bare string rather than emitting a one-character-per-index mess.
+  const platforms = Array.isArray(request.platforms)
+    ? request.platforms
+    : request.platforms
+      ? [request.platforms]
+      : [];
+
+  await sendRequestWebhook({
+    type: "game_request",
+    title: `New Game Request: ${request.title}`,
+    message:
+      `${request.user_name} requested "${request.title}"\n\n` +
+      `Reason: ${request.reason || "No reason provided"}\n` +
+      `Platforms: ${platforms.join(", ") || "Not specified"}`,
+    priority: WEBHOOK_PRIORITIES[request.priority] ?? DEFAULT_WEBHOOK_PRIORITY,
+    data: {
+      request_id: request.id,
+      user_id: request.user_id,
+      game_title: request.title,
+      igdb_id: request.igdb_id,
+      platforms,
+      request_type: request.request_type,
+    },
+    timestamp: new Date().toISOString(),
+  });
+
+  return true;
+}

--- a/src/routes/api/request/+server.js
+++ b/src/routes/api/request/+server.js
@@ -7,6 +7,7 @@ import { json } from "@sveltejs/kit";
 import { query } from "$lib/database.js";
 import { getAuthenticatedUser } from "$lib/auth.server.js";
 import { sendNewRequestNotification } from "$lib/gotify.js";
+import { sendGameRequestWebhook } from "$lib/webhooks.server.js";
 import { invalidateCache } from "$lib/cache.js";
 
 /**
@@ -299,6 +300,14 @@ export async function POST({ request, cookies }) {
     }).catch((error) => {
       console.warn("Failed to send Gotify notification:", error);
       // Don't fail the request if notification fails
+    });
+
+    // Announce the request to whatever automation is configured, for the same
+    // reason and in the same way as the Gotify call above: the row is already
+    // committed, so a slow or absent receiver must not turn a successful
+    // submission into an error for the user.
+    sendGameRequestWebhook(insertedRequest).catch((error) => {
+      console.warn("Failed to send request webhook:", error.message);
     });
 
     return json(

--- a/src/routes/api/webhooks/+server.js
+++ b/src/routes/api/webhooks/+server.js
@@ -4,6 +4,7 @@
 
 import { json, error } from "@sveltejs/kit";
 import { env } from "$env/dynamic/private";
+import { requestWebhookUrl, sendRequestWebhook } from "$lib/webhooks.server.js";
 
 export async function POST({ request }) {
   try {
@@ -114,44 +115,6 @@ async function sendGotifyNotification({ title, message, priority, extras }) {
   return await response.json();
 }
 
-/**
- * The configured outbound webhook URL.
- *
- * REQUEST_WEBHOOK_URL is preferred; N8N_WEBHOOK_URL keeps working so existing
- * installs need no change.
- */
-function requestWebhookUrl() {
-  return (
-    env.REQUEST_WEBHOOK_URL ||
-    process.env.REQUEST_WEBHOOK_URL ||
-    env.N8N_WEBHOOK_URL ||
-    process.env.N8N_WEBHOOK_URL
-  );
-}
-
-/**
- * Send the outbound request webhook.
- */
-async function sendRequestWebhook(payload) {
-  const response = await fetch(requestWebhookUrl(), {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(payload),
-  });
-
-  if (!response.ok) {
-    throw new Error(`Request webhook error: ${response.statusText}`);
-  }
-
-  // Receivers return whatever they like; a non-JSON body is still a success.
-  try {
-    return await response.json();
-  } catch {
-    return { status: "sent", statusCode: response.status };
-  }
-}
-
-// Helper function for common notification types (moved to lib/webhooks.js)
-// This function should be imported from $lib/webhooks.js instead
+// The URL resolution and the dispatch itself live in $lib/webhooks.server.js,
+// which /api/request also uses. Both paths therefore emit an identical payload,
+// and a receiver need not care which one produced it.

--- a/src/tests/unit/request-webhook.test.js
+++ b/src/tests/unit/request-webhook.test.js
@@ -1,0 +1,246 @@
+/**
+ * Regression tests for the outbound request webhook.
+ *
+ * The webhook was documented and configurable, but nothing dispatched it on a
+ * new request: the only builder for the `game_request` payload lived in
+ * `$lib/webhooks.js` and posted to the relative URL "/api/webhooks", which
+ * resolves in a browser and nowhere else. No module imported it. A submitted
+ * request therefore notified Gotify and no receiver ever heard about it.
+ *
+ * These tests pin the payload contract a receiver depends on, and the
+ * resolution order between REQUEST_WEBHOOK_URL and its deprecated alias.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const URL_KEYS = ["REQUEST_WEBHOOK_URL", "N8N_WEBHOOK_URL"];
+
+/** A row as `INSERT ... RETURNING *` hands it back: UUID id, JSONB platforms. */
+function requestRow(overrides = {}) {
+  return {
+    id: "eac1cd44-5f6e-4f49-8ac1-9936066105a6",
+    user_id: "12",
+    user_name: "alice",
+    request_type: "game",
+    title: "Chrono Trigger",
+    igdb_id: "1234",
+    platforms: ["Super Nintendo"],
+    priority: "medium",
+    description: "",
+    reason: "",
+    status: "pending",
+    ...overrides,
+  };
+}
+
+function okResponse() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => ({ received: true }),
+  };
+}
+
+/** The JSON body of the single dispatch that was made. */
+function dispatchedPayload() {
+  expect(global.fetch).toHaveBeenCalledTimes(1);
+  return JSON.parse(global.fetch.mock.calls[0][1].body);
+}
+
+/** Import a pristine copy, so nothing caches a URL across tests. */
+async function freshWebhooks() {
+  vi.resetModules();
+  return import("$lib/webhooks.server.js");
+}
+
+describe("outbound request webhook", () => {
+  beforeEach(() => {
+    for (const key of URL_KEYS) {
+      delete process.env[key];
+    }
+    global.fetch = vi.fn(async () => okResponse());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.doUnmock("$env/dynamic/private");
+  });
+
+  describe("URL resolution", () => {
+    it("dispatches nothing when neither variable is set", async () => {
+      const { sendGameRequestWebhook } = await freshWebhooks();
+
+      await expect(sendGameRequestWebhook(requestRow())).resolves.toBe(false);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("honours the deprecated N8N_WEBHOOK_URL alone, so existing installs keep working", async () => {
+      process.env.N8N_WEBHOOK_URL = "http://legacy.test/hook";
+      const { sendGameRequestWebhook } = await freshWebhooks();
+
+      await expect(sendGameRequestWebhook(requestRow())).resolves.toBe(true);
+      expect(global.fetch.mock.calls[0][0]).toBe("http://legacy.test/hook");
+    });
+
+    it("uses REQUEST_WEBHOOK_URL when set alone", async () => {
+      process.env.REQUEST_WEBHOOK_URL = "http://current.test/hook";
+      const { sendGameRequestWebhook } = await freshWebhooks();
+
+      await sendGameRequestWebhook(requestRow());
+      expect(global.fetch.mock.calls[0][0]).toBe("http://current.test/hook");
+    });
+
+    it("prefers REQUEST_WEBHOOK_URL when both are set", async () => {
+      process.env.REQUEST_WEBHOOK_URL = "http://current.test/hook";
+      process.env.N8N_WEBHOOK_URL = "http://legacy.test/hook";
+      const { sendGameRequestWebhook } = await freshWebhooks();
+
+      await sendGameRequestWebhook(requestRow());
+      expect(global.fetch.mock.calls[0][0]).toBe("http://current.test/hook");
+    });
+
+    it("prefers the runtime env over process.env for the same name", async () => {
+      // A container gets its configuration at start, not at build: the value
+      // SvelteKit resolves at runtime has to win over whatever was baked in.
+      process.env.REQUEST_WEBHOOK_URL = "http://build.test/hook";
+      vi.resetModules();
+      vi.doMock("$env/dynamic/private", () => ({
+        env: { REQUEST_WEBHOOK_URL: "http://runtime.test/hook" },
+      }));
+      const { sendGameRequestWebhook } = await import(
+        "$lib/webhooks.server.js"
+      );
+
+      await sendGameRequestWebhook(requestRow());
+      expect(global.fetch.mock.calls[0][0]).toBe("http://runtime.test/hook");
+    });
+  });
+
+  describe("payload", () => {
+    beforeEach(() => {
+      process.env.REQUEST_WEBHOOK_URL = "http://receiver.test/hook";
+    });
+
+    it("sends the documented shape as JSON", async () => {
+      const { sendGameRequestWebhook } = await freshWebhooks();
+
+      await sendGameRequestWebhook(requestRow());
+
+      const [, init] = global.fetch.mock.calls[0];
+      expect(init.method).toBe("POST");
+      expect(init.headers["Content-Type"]).toBe("application/json");
+
+      const payload = dispatchedPayload();
+      expect(payload.type).toBe("game_request");
+      expect(payload.title).toBe("New Game Request: Chrono Trigger");
+      expect(payload.message).toContain("Chrono Trigger");
+      expect(payload.timestamp).toEqual(expect.any(String));
+      expect(payload.data).toMatchObject({
+        request_id: "eac1cd44-5f6e-4f49-8ac1-9936066105a6",
+        user_id: "12",
+        game_title: "Chrono Trigger",
+        igdb_id: "1234",
+        platforms: ["Super Nintendo"],
+        request_type: "game",
+      });
+    });
+
+    it("keeps platforms an array, which is what a receiver matches on", async () => {
+      const { sendGameRequestWebhook } = await freshWebhooks();
+
+      await sendGameRequestWebhook(
+        requestRow({ platforms: ["Super Nintendo", "Game Boy"] }),
+      );
+
+      expect(dispatchedPayload().data.platforms).toEqual([
+        "Super Nintendo",
+        "Game Boy",
+      ]);
+    });
+
+    it("sends an empty array, not null, when no platform was given", async () => {
+      const { sendGameRequestWebhook } = await freshWebhooks();
+
+      await sendGameRequestWebhook(requestRow({ platforms: null }));
+
+      expect(dispatchedPayload().data.platforms).toEqual([]);
+    });
+
+    it("wraps a bare string platform rather than emitting it as one", async () => {
+      const { sendGameRequestWebhook } = await freshWebhooks();
+
+      await sendGameRequestWebhook(requestRow({ platforms: "Super Nintendo" }));
+
+      expect(dispatchedPayload().data.platforms).toEqual(["Super Nintendo"]);
+    });
+
+    it("orders priority so urgent outranks high", async () => {
+      const { sendGameRequestWebhook } = await freshWebhooks();
+      const priorityFor = async (priority) => {
+        global.fetch.mockClear();
+        await sendGameRequestWebhook(requestRow({ priority }));
+        return dispatchedPayload().priority;
+      };
+
+      const urgent = await priorityFor("urgent");
+      const high = await priorityFor("high");
+      const medium = await priorityFor("medium");
+      const low = await priorityFor("low");
+
+      expect(urgent).toBeGreaterThan(high);
+      expect(high).toBeGreaterThan(medium);
+      expect(medium).toBeGreaterThan(low);
+      // The documented example pins medium.
+      expect(medium).toBe(5);
+    });
+
+    it("survives a request with no reason, without writing 'undefined'", async () => {
+      const { sendGameRequestWebhook } = await freshWebhooks();
+
+      await sendGameRequestWebhook(requestRow({ reason: null }));
+
+      expect(dispatchedPayload().message).not.toContain("undefined");
+    });
+  });
+
+  describe("failure handling", () => {
+    beforeEach(() => {
+      process.env.REQUEST_WEBHOOK_URL = "http://receiver.test/hook";
+    });
+
+    it("reports a rejecting receiver, so the caller can log it", async () => {
+      global.fetch = vi.fn(async () => ({
+        ok: false,
+        status: 502,
+        statusText: "Bad Gateway",
+        json: async () => ({}),
+      }));
+      const { sendGameRequestWebhook } = await freshWebhooks();
+
+      await expect(sendGameRequestWebhook(requestRow())).rejects.toThrow("502");
+    });
+
+    it("gives the receiver a deadline, so a hung one cannot pin the request open", async () => {
+      const { sendGameRequestWebhook } = await freshWebhooks();
+
+      await sendGameRequestWebhook(requestRow());
+
+      expect(global.fetch.mock.calls[0][1].signal).toBeDefined();
+    });
+
+    it("treats a non-JSON body from the receiver as success", async () => {
+      global.fetch = vi.fn(async () => ({
+        ok: true,
+        status: 204,
+        statusText: "No Content",
+        json: async () => {
+          throw new SyntaxError("Unexpected end of JSON input");
+        },
+      }));
+      const { sendGameRequestWebhook } = await freshWebhooks();
+
+      await expect(sendGameRequestWebhook(requestRow())).resolves.toBe(true);
+    });
+  });
+});

--- a/tests/integration/request-webhook-dispatch.test.js
+++ b/tests/integration/request-webhook-dispatch.test.js
@@ -1,0 +1,162 @@
+/**
+ * Regression test for webhook dispatch on request submission.
+ *
+ * The webhook was configurable and documented, but no code path fired it. The
+ * only builder for the `game_request` payload lived in `$lib/webhooks.js`,
+ * posting to the relative URL "/api/webhooks" -- browser-only, and imported by
+ * nobody. A submitted request notified Gotify and stopped there, so an
+ * automation pointed at REQUEST_WEBHOOK_URL never learned a request existed.
+ *
+ * This pins the wiring rather than the payload: that POST /api/request itself
+ * dispatches, and that it stays fire-and-forget so a broken receiver cannot
+ * fail a submission the database has already accepted.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const USER = { auth_type: "api_key", user_id: "12", name: "alice" };
+
+const INSERTED_ROW = {
+  id: "eac1cd44-5f6e-4f49-8ac1-9936066105a6",
+  user_id: "12",
+  user_name: "alice",
+  request_type: "game",
+  title: "Chrono Trigger",
+  igdb_id: "1234",
+  platforms: ["Super Nintendo"],
+  priority: "medium",
+  description: "",
+  reason: null,
+  status: "pending",
+};
+
+const getAuthenticatedUser = vi.fn(async () => USER);
+const sendNewRequestNotification = vi.fn(async () => true);
+
+// Route the two statements the handler runs before it reaches the webhook.
+const query = vi.fn(async (sql) => {
+  if (sql.includes("INSERT INTO ggr_game_requests")) {
+    return { rows: [INSERTED_ROW] };
+  }
+  if (sql.includes("FROM ggr_users")) {
+    return { rows: [{ id: "12", username: "alice", email: "a@example.test" }] };
+  }
+  return { rows: [] };
+});
+
+vi.mock("$lib/database.js", () => ({
+  query,
+  gameCache: { upsert: vi.fn(async () => {}) },
+}));
+vi.mock("$lib/auth.server.js", () => ({ getAuthenticatedUser }));
+vi.mock("$lib/gotify.js", () => ({ sendNewRequestNotification }));
+vi.mock("$lib/cache.js", () => ({ invalidateCache: vi.fn(async () => {}) }));
+
+/** Submit a request through the real handler. */
+async function submitRequest(body = {}) {
+  vi.resetModules();
+  const { POST } = await import("../../src/routes/api/request/+server.js");
+
+  const response = await POST({
+    cookies: {},
+    request: new Request("http://localhost/api/request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        request_type: "game",
+        title: "Chrono Trigger",
+        platforms: ["Super Nintendo"],
+        igdb_id: "1234",
+        ...body,
+      }),
+    }),
+  });
+
+  // The dispatch is deliberately not awaited by the handler. Let its
+  // continuation run before asserting on it.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return response;
+}
+
+/** Calls made to the configured receiver, ignoring anything else. */
+function webhookCalls() {
+  return global.fetch.mock.calls.filter(
+    ([url]) => String(url) === "http://receiver.test/hook",
+  );
+}
+
+describe("POST /api/request webhook dispatch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.REQUEST_WEBHOOK_URL = "http://receiver.test/hook";
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({ received: true }),
+    }));
+  });
+
+  afterEach(() => {
+    delete process.env.REQUEST_WEBHOOK_URL;
+    vi.restoreAllMocks();
+  });
+
+  it("dispatches the webhook for a newly created request", async () => {
+    const response = await submitRequest();
+    expect(response.status).toBe(201);
+
+    const calls = webhookCalls();
+    expect(calls).toHaveLength(1);
+
+    const payload = JSON.parse(calls[0][1].body);
+    expect(payload.type).toBe("game_request");
+    expect(payload.data.game_title).toBe("Chrono Trigger");
+    expect(payload.data.platforms).toEqual(["Super Nintendo"]);
+    expect(payload.data.request_id).toBe(INSERTED_ROW.id);
+  });
+
+  it("sends the stored row, not the submitted body", async () => {
+    // The client may send anything; the receiver must see what was persisted.
+    await submitRequest({ title: "Chrono Trigger", igdb_id: "9999" });
+
+    expect(JSON.parse(webhookCalls()[0][1].body).data.igdb_id).toBe("1234");
+  });
+
+  it("still succeeds when the receiver rejects the webhook", async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: async () => ({}),
+    }));
+
+    const response = await submitRequest();
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toMatchObject({ success: true });
+  });
+
+  it("still succeeds when the receiver is unreachable", async () => {
+    global.fetch = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+
+    expect((await submitRequest()).status).toBe(201);
+  });
+
+  it("dispatches nothing when no webhook is configured", async () => {
+    delete process.env.REQUEST_WEBHOOK_URL;
+
+    const response = await submitRequest();
+
+    expect(response.status).toBe(201);
+    expect(webhookCalls()).toHaveLength(0);
+  });
+
+  it("keeps notifying Gotify, which the webhook does not replace", async () => {
+    await submitRequest();
+
+    expect(sendNewRequestNotification).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What

Makes the outbound request webhook actually fire when a request is submitted.

## Why

This follows directly from your answer on #8:

> Every request fires a webhook with the game title, platforms and IGDB ID. Point REQUEST_WEBHOOK_URL at your own service and drive Prowlarr/qBittorrent from there.

That is the right answer, and I agree it is the right boundary for core — but on `main` today the webhook never fires on a request, so the integration path you pointed at cannot be built.

The only builder for the `game_request` payload is `sendGameRequestNotification` in `src/lib/webhooks.js`, and it posts to the **relative** URL `/api/webhooks`:

```js
return await fetch("/api/webhooks", { ... });
```

A relative URL resolves in a browser and nowhere else, so it was unusable from an endpoint — and nothing imports it:

```
$ git grep -n "sendGameRequestNotification" -- src
src/lib/webhooks.js:8:export async function sendGameRequestNotification(requestData) {
```

`POST /api/request` calls Gotify and returns. So a submitted request notified Gotify and stopped there: `/api/webhooks` only dispatches for whoever POSTs to it, and for a new request nobody does.

This is how I found it. I was wiring requests into a download automation service, concluded from the docs that the capability existed, configured it, and got nothing — which is also what prompted #10.

## Changes

- **`src/lib/webhooks.server.js`** (new) — the URL resolution and the dispatch, server side. `sendGameRequestWebhook(row)` builds the documented payload from the inserted row.
- **`src/routes/api/request/+server.js`** — call it after the insert, beside the existing Gotify call and in the same fire-and-forget style.
- **`src/routes/api/webhooks/+server.js`** — import those two functions instead of keeping private copies, so both paths emit a byte-identical payload.
- **`src/lib/webhooks.js`** — note that these helpers are browser-only and which module server callers want. No signature changes; I left the exports alone in case anything downstream imports them.
- **`docs/guides/INTEGRATIONS.md`** — say when the webhook fires, and correct the payload example.

## Two behaviour changes worth flagging

**`/api/webhooks` now has a 5s deadline on the receiver.** It previously had none, so a receiver that accepted the connection and never answered would hold the endpoint open indefinitely. `/api/request` needed a bound anyway; sharing the sender gives both one.

**`urgent` now outranks `high` in the payload's `priority`.** The old mapping was `high → 8, low → 3, else → 5`, so `urgent` fell through to the medium value and ranked *below* `high` — the one ordering a receiver is likely to act on. Now `low` 3, `medium` 5, `high` 8, `urgent` 9, documented. Since the webhook has never actually fired on a request, no receiver can be relying on the old mapping.

## Payload example correction

The example I wrote in #10 had the id types wrong. `ggr_game_requests.id` is `UUID`, and `user_id` / `igdb_id` are `TEXT`:

```
id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
user_id TEXT NOT NULL,
igdb_id TEXT,
platforms JSONB DEFAULT '[]',
```

The doc showed `"request_id": 42` and `"igdb_id": 1234`. A receiver written against integers breaks on the first real payload, so that is fixed here along with a note on the `platforms` array and the priority scale.

## Testing

`npm run lint` clean, and the full suite passes — 63 unit, 15 integration.

**`src/tests/unit/request-webhook.test.js`** (14 tests) covers the payload contract and the URL resolution order across all four configurations, including that the runtime env beats a value baked in at build time:

| config | resolves to |
|---|---|
| neither | no dispatch, no fetch |
| `N8N_WEBHOOK_URL` only | that URL — existing installs unaffected |
| `REQUEST_WEBHOOK_URL` only | that URL |
| both | `REQUEST_WEBHOOK_URL` |

Plus `platforms` staying an array (including empty rather than null), the priority ordering, a rejecting receiver, and a non-JSON success body.

**`tests/integration/request-webhook-dispatch.test.js`** (6 tests) pins the wiring rather than the payload, since the wiring is what was missing — it drives the real `POST` handler with the database and auth mocked. Both dispatch assertions fail against `main` as it stands:

```
FAIL  POST /api/request webhook dispatch > dispatches the webhook for a newly created request
AssertionError: expected [] to have a length of 1 but got +0
```

It also checks the submission still returns 201 when the receiver 500s and when it refuses the connection, that nothing is sent when unconfigured, and that Gotify still fires — the webhook adds a receiver, it does not replace one.

## Verified on a live instance

Running this build against a 72,000-rom ROMM library with `REQUEST_WEBHOOK_URL` pointed at a download automation service, submitting through the API:

```
POST /api/request  →  201
{"success":true,"request":{"id":"49db1200-91fe-4b76-8393-9d84ca15ebb9","title":"Chrono Trigger", ...}}
```

The receiver acted on it 11 seconds later, off `data.game_title` and `data.platforms` with no translation:

```json
{"game": "Chrono Trigger", "platform": "snes", "state": "grabbed", "at": "2026-07-29T20:12:52+00:00"}
```

On the build before this change, the same submission produced the same 201 and nothing downstream — which is the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
