### PR TITLE
Skip the ROMM /roms aggregates this client never reads

### DIFF
--- a/src/lib/romm.server.js
+++ b/src/lib/romm.server.js
@@ -11,13 +11,55 @@ import { fetchWithTimeout, isTimeoutOrNetworkError } from "./utils.js";
 // reached over a public URL, so a slow or unreachable instance previously
 // stalled every request that touched it.
 const AUTH_TIMEOUT_MS = 5000;
-const REQUEST_TIMEOUT_MS = 5000;
+// These were tuned against a small library, where /roms answered in well under
+// a second. On a 72,000-rom library the same call takes a few seconds even with
+// the aggregate opt-out below, so a 5s per-attempt budget had no headroom: the
+// first probe after startup aborted and tripped the circuit breaker, which
+// reports as "ROMM is unreachable" -- indistinguishable from the service being
+// down, and the reason a healthy instance looked broken for five minutes at a
+// time.
+const REQUEST_TIMEOUT_MS = 10000;
 // Hard ceiling across all retries for a single logical request.
-const TOTAL_BUDGET_MS = 12000;
+const TOTAL_BUDGET_MS = 30000;
 
 // Renew this far ahead of the stated expiry so a request never leaves carrying
 // a token that dies in transit.
 const TOKEN_REFRESH_MARGIN_MS = 60 * 1000;
+
+// ROMM computes two aggregates for every /roms call unless told otherwise: an
+// A-Z jump index (`char_index`) and the facet lists behind its filter sidebar
+// (`filter_values`). Both are computed over the entire roms table, so `limit`
+// cannot make them cheaper -- an aggregate over everything is the whole point
+// of one. On a large library they dominate the request.
+//
+// Nothing in this codebase reads either one; every caller destructures `items`
+// and `total`. Measured against a 72,162-rom library, opting out took the
+// availability probe from 30.5s to 2.3s. With the 5s budget above, that is the
+// difference between a working integration and a permanent "ROMM is
+// unreachable" -- which is how this presented, since a timeout looks identical
+// to a service being down.
+const ROMM_UNUSED_AGGREGATES = {
+  with_char_index: "false",
+  with_filter_values: "false",
+};
+
+/**
+ * Opt a /roms request out of aggregates this client never reads.
+ * @param {string} endpoint - API endpoint, with or without a query string
+ * @returns {string} - The endpoint, with the opt-out applied
+ */
+function withoutUnusedAggregates(endpoint) {
+  const [path, query = ""] = endpoint.split("?");
+  // Only the collection endpoint computes them; /roms/{id} has none to skip.
+  if (path !== "/roms") return endpoint;
+
+  const params = new URLSearchParams(query);
+  for (const [key, value] of Object.entries(ROMM_UNUSED_AGGREGATES)) {
+    // Never override a caller that asked for one deliberately.
+    if (!params.has(key)) params.set(key, value);
+  }
+  return `${path}?${params}`;
+}
 // RomM's password grant issues a 30-minute token. When the response omits the
 // lifetime, assume less than that rather than more.
 const DEFAULT_TOKEN_TTL_MS = 25 * 60 * 1000;
@@ -387,7 +429,7 @@ async function rommAttempt(
   }
 
   const fetchOptions = { ...options, headers };
-  const url = `${ROMM_SERVER_URL}/api${endpoint}`;
+  const url = `${ROMM_SERVER_URL}/api${withoutUnusedAggregates(endpoint)}`;
 
   /** Wait for the backoff, but never past the overall deadline. */
   const backoff = async () => {

--- a/src/routes/api/setup/check/+server.js
+++ b/src/routes/api/setup/check/+server.js
@@ -161,7 +161,11 @@ async function testROMM() {
     // instead, which is what the app actually calls.
     const response = rommToken
       ? await fetchWithTimeout(
-          `${rommUrl}/api/roms?group_by_meta_id=false&limit=1&offset=0`,
+          `${rommUrl}/api/roms?group_by_meta_id=false&limit=1&offset=0` +
+            // Skip the char index and filter facets: this only checks
+            // that the token works, and both aggregate over the whole
+            // library. See romm.server.js for the measurements.
+            "&with_char_index=false&with_filter_values=false",
           {
             headers: {
               Authorization: `Bearer ${rommToken}`,

--- a/tests/integration/romm-query-shape.test.js
+++ b/tests/integration/romm-query-shape.test.js
@@ -1,0 +1,143 @@
+/**
+ * Regression tests for the shape of the /roms query this client sends.
+ *
+ * ROMM computes two aggregates for every /roms call unless told otherwise: the
+ * A-Z jump index (`char_index`) and the facet lists behind its filter sidebar
+ * (`filter_values`). Both aggregate over the whole roms table, so `limit`
+ * cannot make them cheaper. Nothing here reads either -- every caller
+ * destructures `items` and `total`.
+ *
+ * On a 72,162-rom library the availability probe took 30.5s warm with them and
+ * 2.3s without, which against the per-attempt timeout is the difference between
+ * a working integration and a permanent "ROMM is unreachable": a timed-out
+ * probe trips the availability breaker, and that is indistinguishable from the
+ * service being down.
+ *
+ * These pin the opt-out, and that it stays confined to the collection endpoint.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// romm.server.js imports this at module scope for IGDB cover lookups. Nothing
+// under test reaches it, but the real module pulls in the database pool.
+vi.mock("../../src/lib/gameCache.js", () => ({
+  getGameById: vi.fn(async () => null),
+}));
+
+const ROMM_URL = "http://romm.test";
+
+function response(status, body = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: `Status ${status}`,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+/** URLs passed to fetch, in order. */
+function calledUrls() {
+  return global.fetch.mock.calls.map(([url]) => String(url));
+}
+
+/** The query string of the /roms collection call, parsed. */
+function romsQuery() {
+  const url = calledUrls().find((candidate) =>
+    candidate.startsWith(`${ROMM_URL}/api/roms?`),
+  );
+  expect(url, "expected a /roms call").toBeDefined();
+  return new URL(url).searchParams;
+}
+
+/** Import a pristine copy; token and availability state are module-scoped. */
+async function freshRomm() {
+  vi.resetModules();
+  return import("../../src/lib/romm.server.js");
+}
+
+describe("ROMM /roms query shape", () => {
+  beforeEach(() => {
+    process.env.ROMM_SERVER_URL = ROMM_URL;
+    process.env.ROMM_API_TOKEN = "rmm_static_token";
+    delete process.env.ROMM_USERNAME;
+    delete process.env.ROMM_PASSWORD;
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(response(200, { items: [], total: 0 }));
+  });
+
+  it("opts the availability probe out of both aggregates", async () => {
+    const { probeRommAvailability } = await freshRomm();
+
+    await probeRommAvailability();
+
+    const query = romsQuery();
+    expect(query.get("with_char_index")).toBe("false");
+    expect(query.get("with_filter_values")).toBe("false");
+  });
+
+  it("keeps the parameters the caller asked for", async () => {
+    const { probeRommAvailability } = await freshRomm();
+
+    await probeRommAvailability();
+
+    const query = romsQuery();
+    expect(query.get("group_by_meta_id")).toBe("false");
+    expect(query.get("limit")).toBe("1");
+    expect(query.get("offset")).toBe("0");
+  });
+
+  it("opts the library listing out too, not just the probe", async () => {
+    const { getRecentlyAddedROMs } = await freshRomm();
+
+    await getRecentlyAddedROMs(16, 0);
+
+    const query = romsQuery();
+    expect(query.get("with_char_index")).toBe("false");
+    expect(query.get("with_filter_values")).toBe("false");
+    // The listing's own ordering has to survive the rewrite.
+    expect(query.get("order_by")).toBe("created_at");
+    expect(query.get("order_dir")).toBe("desc");
+  });
+
+  it("opts search out too, without disturbing its ordering", async () => {
+    const { searchROMs } = await freshRomm();
+
+    await searchROMs("chrono trigger");
+
+    const query = romsQuery();
+    expect(query.get("with_char_index")).toBe("false");
+    expect(query.get("with_filter_values")).toBe("false");
+    expect(query.get("search_term")).toBe("chrono trigger");
+    // ROMM's default ordering is what makes search results relevant, so the
+    // opt-out must not smuggle in an order_by.
+    expect(query.has("order_by")).toBe(false);
+  });
+
+  it("leaves a single-ROM fetch alone, which has no aggregates to skip", async () => {
+    // This one gets a ROM-shaped body, since it formats what it receives.
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(response(200, { id: "123", name: "Chrono Trigger" }));
+    const { getROMById } = await freshRomm();
+
+    await getROMById("123");
+
+    const url = calledUrls().find((candidate) =>
+      candidate.includes("/api/roms/123"),
+    );
+    expect(url).toBe(`${ROMM_URL}/api/roms/123`);
+  });
+
+  it("leaves endpoints that are not /roms alone", async () => {
+    const { getPlatforms } = await freshRomm();
+
+    await getPlatforms();
+
+    const url = calledUrls().find((candidate) =>
+      candidate.includes("/platforms"),
+    );
+    expect(url).toBe(`${ROMM_URL}/api/platforms`);
+  });
+});

--- a/tests/integration/romm-token-lifecycle.test.js
+++ b/tests/integration/romm-token-lifecycle.test.js
@@ -21,10 +21,14 @@ vi.mock("../../src/lib/gameCache.js", () => ({
 
 const ROMM_URL = "http://romm.test";
 const TOKEN_URL = `${ROMM_URL}/api/token`;
-const LIBRARY_PATH = "/api/roms?group_by_meta_id=false&limit=1&offset=0";
+// The client opts every /roms call out of ROMM's char-index and filter-value
+// aggregates, which it never reads. See romm-query-shape.test.js.
+const LIBRARY_PATH =
+  "/api/roms?group_by_meta_id=false&limit=1&offset=0" +
+  "&with_char_index=false&with_filter_values=false";
 
 // Tests that let the retry loop run to exhaustion wait out the real 1s + 2s +
-// 4s backoff, bounded by the client's own 12s TOTAL_BUDGET_MS.
+// 4s backoff, well inside the client's own TOTAL_BUDGET_MS.
 const RETRY_BUDGET_TEST_TIMEOUT = 20000;
 
 /** Build a minimal Response-alike for the fetch mock. */


### PR DESCRIPTION
## What

Opts every `/roms` call out of two aggregates this client never reads, and gives the outbound budgets enough headroom for a large library.

## Why

ROMM computes two things for every `/roms` call unless told otherwise: the A-Z jump index (`char_index`) and the facet lists behind its filter sidebar (`filter_values`). Both aggregate over the **entire** roms table, so `limit=1` cannot make them cheaper — aggregating over everything is the point of an aggregate.

Nothing in this codebase reads either one. Every caller destructures `items` and `total`:

```
$ git grep -c "char_index\|filter_values" main -- src
no matches
```

They are not mentioned anywhere in `src` on `main` — the app has never asked for them or consumed them; it just pays for them by default.

Measured against a 72,162-rom library, on the availability probe (`/roms?group_by_meta_id=false&limit=1&offset=0`), under the app's own timeout budget:

| query | time |
|---|---|
| what we send today | **30.5s** warm / 293.9s cold |
| `with_char_index=false&with_filter_values=false` | **2.3s** |

## How this presented

Not as slowness — as `"Could not reach the ROMM server"`.

At ~30s per call against a 5s per-attempt timeout, the first probe after startup aborted, which trips the availability breaker and caches "unavailable" for five minutes. That surfaces as an unreachable-service message, indistinguishable from ROMM actually being down, with a perfectly healthy instance one `curl` away. I spent a while looking at networking before looking at the query.

## Changes

- **`src/lib/romm.server.js`** — a `withoutUnusedAggregates()` helper applied at the single URL-construction site in `rommAttempt`, so every `/roms` caller benefits without touching call sites. Scoped to the collection endpoint: `/roms/{id}` and `/platforms` pass through untouched. Existing parameters are preserved, and it sets defaults rather than overriding a caller that asks for an aggregate deliberately.
- **`src/routes/api/setup/check/+server.js`** — the same opt-out; this route builds its own URL rather than going through the client.
- **Budgets** — `REQUEST_TIMEOUT_MS` 5s → 10s, `TOTAL_BUDGET_MS` 12s → 30s.

## On the budgets

Happy to drop this half if you would rather keep them as they are — the aggregate opt-out stands on its own and is the bulk of the win.

The argument for including it: the opt-out gets the warm probe to 2.3s, but the *cold* one is much slower still, and the cold probe is exactly the first call after a container start. With a 5s per-attempt ceiling that first probe can still abort and still trip the breaker, so the failure mode survives the fix on a large library.

The tradeoff is real and worth stating: a genuinely dead ROMM now takes longer to declare dead. The breaker caches the verdict, so it is paid once per five minutes per worker rather than per request.

I did **not** add `order_by=id`, though it takes the same probe from 2.3s to 1.1s. `searchROMs` depends on ROMM's default ordering for relevance, and the helper is shared, so defaulting an order there would quietly degrade search.

## Testing

`npm run lint` clean, 63 unit and 15 integration tests pass.

**`tests/integration/romm-query-shape.test.js`** (new, 6 tests) pins the opt-out on the probe, the recently-added listing and search; that the listing keeps its `order_by=created_at&order_dir=desc`; that search keeps `search_term` and gains no `order_by`; and that `/roms/123` and `/platforms` are left exactly as they were.

**`tests/integration/romm-token-lifecycle.test.js`** — updated: its `LIBRARY_PATH` asserts the exact probe URL, which now carries the two parameters. Also dropped a stale reference to the 12s budget in a comment. No behavioural change to what it tests; retry-exhaustion timings are set by the 1s+2s+4s backoff, not the total budget, so those tests still run in ~7s.

## Verified on a live instance

Same 72,162-rom library, probe URL as the client now builds it:

```
attempt 1: 200 in 2.308119s
attempt 2: 200 in 2.487905s
```

Down from 30.5s, and the "unreachable" false alarm has not recurred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
