### PR TITLE
Skip comments when splitting migration statements

### DIFF
--- a/scripts/database/db-manager.js
+++ b/scripts/database/db-manager.js
@@ -11,6 +11,7 @@ import { fileURLToPath } from "url";
 import crypto from "crypto";
 import { config } from "dotenv";
 import pkg from "pg";
+import { splitSQLStatements } from "./sql-statements.js";
 const { Client } = pkg;
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,87 +78,6 @@ function getDbClient() {
     ssl: process.env.DB_SSL === "true" ? { rejectUnauthorized: false } : false,
   });
   return client;
-}
-
-/**
- * Split SQL statements intelligently, handling PostgreSQL functions
- */
-function splitSQLStatements(sql) {
-  const statements = [];
-  let current = "";
-  let inSingleQuote = false;
-  let inDoubleQuote = false;
-  let inDollarQuote = false;
-  let dollarTag = "";
-  let inFunction = false;
-
-  for (let i = 0; i < sql.length; i++) {
-    const char = sql[i];
-
-    current += char;
-
-    // Handle dollar quoting (PostgreSQL function bodies)
-    if (char === "$" && !inSingleQuote && !inDoubleQuote) {
-      if (!inDollarQuote) {
-        const match = sql.substring(i).match(/^\$([^$]*)\$/);
-        if (match) {
-          dollarTag = match[1];
-          inDollarQuote = true;
-          current += match[0].substring(1);
-          i += match[0].length - 1;
-          continue;
-        }
-      } else {
-        const expectedEnd = `$${dollarTag}$`;
-        if (sql.substring(i).startsWith(expectedEnd)) {
-          inDollarQuote = false;
-          current += expectedEnd.substring(1);
-          i += expectedEnd.length - 1;
-          continue;
-        }
-      }
-    }
-
-    // Handle regular quotes
-    if (!inDollarQuote) {
-      if (char === "'" && !inDoubleQuote) inSingleQuote = !inSingleQuote;
-      if (char === '"' && !inSingleQuote) inDoubleQuote = !inDoubleQuote;
-    }
-
-    // Check for function keywords
-    if (!inSingleQuote && !inDoubleQuote && !inDollarQuote) {
-      const remaining = sql.substring(i).toLowerCase();
-      if (remaining.startsWith("create") && remaining.includes("function")) {
-        inFunction = true;
-      }
-      if (inFunction && remaining.startsWith("language")) {
-        inFunction = false;
-      }
-    }
-
-    // Statement separator
-    if (
-      char === ";" &&
-      !inSingleQuote &&
-      !inDoubleQuote &&
-      !inDollarQuote &&
-      !inFunction
-    ) {
-      const statement = current.trim();
-      if (statement && statement !== ";") {
-        statements.push(statement);
-      }
-      current = "";
-    }
-  }
-
-  // Add final statement if exists
-  const finalStatement = current.trim();
-  if (finalStatement && finalStatement !== ";") {
-    statements.push(finalStatement);
-  }
-
-  return statements.filter((stmt) => stmt.length > 0);
 }
 
 /**

--- a/scripts/database/sql-statements.js
+++ b/scripts/database/sql-statements.js
@@ -1,10 +1,20 @@
 /**
  * Splitting a migration file into statements.
  *
- * Extracted from db-manager.js so it can be tested without importing the CLI,
- * which connects to a database on import.
+ * Extracted from db-manager.js so it can be tested without importing the CLI.
+ *
+ * The hard part is knowing which characters are structural and which are just
+ * text. A semicolon inside a string literal, a dollar-quoted function body, or
+ * a comment is not a statement separator, and an apostrophe inside a comment is
+ * not the start of a string.
  */
 
+/**
+ * Split a SQL script into individual statements.
+ *
+ * @param {string} sql - The full text of a migration file
+ * @returns {string[]} - Statements, comments retained, empties dropped
+ */
 export function splitSQLStatements(sql) {
   const statements = [];
   let current = "";
@@ -13,9 +23,49 @@ export function splitSQLStatements(sql) {
   let inDollarQuote = false;
   let dollarTag = "";
   let inFunction = false;
+  let inLineComment = false;
+  let inBlockComment = false;
 
   for (let i = 0; i < sql.length; i++) {
     const char = sql[i];
+    const next = sql[i + 1];
+
+    // Comments are copied through untouched but never interpreted. Without
+    // this, an apostrophe in a comment ("the route's handler") flipped quote
+    // tracking for the remainder of the file, collapsing every later statement
+    // into one, and a semicolon in a comment split it mid-sentence and handed
+    // Postgres the tail as a bare statement -- which, since AUTO_MIGRATE runs
+    // at container start, failed the boot.
+    if (inLineComment) {
+      current += char;
+      if (char === "\n") inLineComment = false;
+      continue;
+    }
+
+    if (inBlockComment) {
+      current += char;
+      if (char === "*" && next === "/") {
+        current += next;
+        i += 1;
+        inBlockComment = false;
+      }
+      continue;
+    }
+
+    if (!inSingleQuote && !inDoubleQuote && !inDollarQuote) {
+      if (char === "-" && next === "-") {
+        current += char + next;
+        i += 1;
+        inLineComment = true;
+        continue;
+      }
+      if (char === "/" && next === "*") {
+        current += char + next;
+        i += 1;
+        inBlockComment = true;
+        continue;
+      }
+    }
 
     current += char;
 

--- a/scripts/database/sql-statements.js
+++ b/scripts/database/sql-statements.js
@@ -1,0 +1,84 @@
+/**
+ * Splitting a migration file into statements.
+ *
+ * Extracted from db-manager.js so it can be tested without importing the CLI,
+ * which connects to a database on import.
+ */
+
+export function splitSQLStatements(sql) {
+  const statements = [];
+  let current = "";
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+  let inDollarQuote = false;
+  let dollarTag = "";
+  let inFunction = false;
+
+  for (let i = 0; i < sql.length; i++) {
+    const char = sql[i];
+
+    current += char;
+
+    // Handle dollar quoting (PostgreSQL function bodies)
+    if (char === "$" && !inSingleQuote && !inDoubleQuote) {
+      if (!inDollarQuote) {
+        const match = sql.substring(i).match(/^\$([^$]*)\$/);
+        if (match) {
+          dollarTag = match[1];
+          inDollarQuote = true;
+          current += match[0].substring(1);
+          i += match[0].length - 1;
+          continue;
+        }
+      } else {
+        const expectedEnd = `$${dollarTag}$`;
+        if (sql.substring(i).startsWith(expectedEnd)) {
+          inDollarQuote = false;
+          current += expectedEnd.substring(1);
+          i += expectedEnd.length - 1;
+          continue;
+        }
+      }
+    }
+
+    // Handle regular quotes
+    if (!inDollarQuote) {
+      if (char === "'" && !inDoubleQuote) inSingleQuote = !inSingleQuote;
+      if (char === '"' && !inSingleQuote) inDoubleQuote = !inDoubleQuote;
+    }
+
+    // Check for function keywords
+    if (!inSingleQuote && !inDoubleQuote && !inDollarQuote) {
+      const remaining = sql.substring(i).toLowerCase();
+      if (remaining.startsWith("create") && remaining.includes("function")) {
+        inFunction = true;
+      }
+      if (inFunction && remaining.startsWith("language")) {
+        inFunction = false;
+      }
+    }
+
+    // Statement separator
+    if (
+      char === ";" &&
+      !inSingleQuote &&
+      !inDoubleQuote &&
+      !inDollarQuote &&
+      !inFunction
+    ) {
+      const statement = current.trim();
+      if (statement && statement !== ";") {
+        statements.push(statement);
+      }
+      current = "";
+    }
+  }
+
+  // Add final statement if exists
+  const finalStatement = current.trim();
+  if (finalStatement && finalStatement !== ";") {
+    statements.push(finalStatement);
+  }
+
+  return statements.filter((stmt) => stmt.length > 0);
+}

--- a/src/tests/unit/sql-statements.test.js
+++ b/src/tests/unit/sql-statements.test.js
@@ -1,0 +1,123 @@
+/**
+ * Regression tests for migration statement splitting.
+ *
+ * The splitter tracked string literals and dollar-quoted bodies but never
+ * skipped comments, so a comment's contents were interpreted as SQL. Two
+ * consequences, both hit in real migrations and neither visible through
+ * `psql -f`, which parses comments correctly:
+ *
+ *   - A semicolon in a comment split the statement and handed Postgres the
+ *     comment's tail as a bare statement. `AUTO_MIGRATE` runs migrations at
+ *     container start, so that failed the boot.
+ *   - An apostrophe in a comment flipped quote tracking for the rest of the
+ *     file, so every later semicolon looked like it was inside a string and
+ *     the whole migration collapsed into one statement. That one still
+ *     "worked" — node-postgres sends a parameterless query over the simple
+ *     protocol, which allows multiple commands — but per-statement error
+ *     attribution was silently lost.
+ */
+
+import { describe, expect, it } from "vitest";
+import { splitSQLStatements } from "../../../scripts/database/sql-statements.js";
+
+describe("splitSQLStatements", () => {
+  it("splits ordinary statements", () => {
+    const statements = splitSQLStatements("SELECT 1;\nSELECT 2;\nSELECT 3;\n");
+
+    expect(statements).toHaveLength(3);
+  });
+
+  it("does not split on a semicolon inside a line comment", () => {
+    // The exact shape that failed a container boot: prose with a semicolon.
+    const sql = `-- Seeding it changes no behaviour; it only lets an admin grant it.
+INSERT INTO t (a) VALUES (1);
+`;
+
+    const statements = splitSQLStatements(sql);
+
+    expect(statements).toHaveLength(1);
+    expect(statements[0]).toContain("INSERT INTO t");
+  });
+
+  it("does not let an apostrophe in a comment swallow the rest of the file", () => {
+    // Four statements, and a possessive apostrophe in the header comment.
+    const sql = `-- Fixes the route's error handler.
+SELECT 1;
+SELECT 2;
+SELECT 3;
+SELECT 4;
+`;
+
+    expect(splitSQLStatements(sql)).toHaveLength(4);
+  });
+
+  it("ignores a semicolon inside a block comment", () => {
+    const sql = `/* one; two; three */
+SELECT 1;
+SELECT 2;
+`;
+
+    expect(splitSQLStatements(sql)).toHaveLength(2);
+  });
+
+  it("keeps comment text in the statement it precedes", () => {
+    const statements = splitSQLStatements("-- why\nSELECT 1;\n");
+
+    expect(statements[0]).toContain("-- why");
+    expect(statements[0]).toContain("SELECT 1");
+  });
+
+  it("still treats a semicolon inside a string literal as text", () => {
+    const statements = splitSQLStatements(
+      "INSERT INTO t (a) VALUES ('one; two');\nSELECT 1;\n",
+    );
+
+    expect(statements).toHaveLength(2);
+    expect(statements[0]).toContain("'one; two'");
+  });
+
+  it("does not mistake a double dash inside a string literal for a comment", () => {
+    const statements = splitSQLStatements(
+      "INSERT INTO t (a) VALUES ('a -- b');\nSELECT 1;\n",
+    );
+
+    expect(statements).toHaveLength(2);
+    expect(statements[0]).toContain("'a -- b'");
+  });
+
+  it("keeps a dollar-quoted body with semicolons as one statement", () => {
+    const sql = `CREATE OR REPLACE FUNCTION bump() RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ language 'plpgsql';
+SELECT 1;
+`;
+
+    const statements = splitSQLStatements(sql);
+
+    expect(statements).toHaveLength(2);
+    expect(statements[0]).toContain("RETURN NEW;");
+  });
+
+  it("counts the statements in a migration shaped like a real one", () => {
+    // Two comment blocks containing an apostrophe and a semicolon, two data
+    // fix-ups and two index creations: six semicolons, four statements.
+    const sql = `-- Guard against duplicates.
+--
+-- Scoped to open rows only; a rejected request must not block a retry, and
+-- the route's own pre-check gives the friendly message.
+
+UPDATE t SET status = 'cancelled' WHERE id = 1;
+
+UPDATE t SET status = 'cancelled' WHERE id = 2;
+
+CREATE UNIQUE INDEX IF NOT EXISTS t_a_uniq ON t (a) WHERE status IN ('open');
+
+CREATE UNIQUE INDEX IF NOT EXISTS t_b_uniq ON t (lower(b)) WHERE status IN ('open');
+`;
+
+    expect(splitSQLStatements(sql)).toHaveLength(4);
+  });
+});


### PR DESCRIPTION
## What

Makes the migration statement splitter skip comments instead of interpreting them.

## Why

`splitSQLStatements` tracks string literals and dollar-quoted bodies, but never skips `--` or `/* */` comments, so a comment's contents are read as SQL. Two separate consequences, both of which I hit writing migrations, and neither of which `psql -f` reveals — psql parses comments correctly, so a migration can be verified by hand and still fail through the app.

**A semicolon in a comment aborts the container boot.** It splits the statement and hands Postgres the comment's tail:

```sql
-- Seeding it changes no behaviour; it only lets an administrator grant it.
INSERT INTO ggr_permissions ...
```
```
ERROR:  syntax error at or near "it"
```

`AUTO_MIGRATE` runs migrations at container start, so the migration fails and the boot fails with it. An ordinary English semicolon in a comment is enough.

**An apostrophe in a comment silently collapses the whole file into one statement.** It flips quote tracking for everything after it, so every later semicolon looks like it is inside a string:

```sql
-- Fixes the route's error handler.
SELECT 1;
SELECT 2;
SELECT 3;
SELECT 4;
```
→ **1** statement instead of 4.

That one keeps working, which is why it has gone unnoticed: node-postgres sends a parameterless query over the simple protocol and Postgres accepts multiple commands that way. What is lost is per-statement error attribution — `runMigrations` logs a single `error.message` for the whole file, so a failure in a 20-statement migration says nothing about which statement produced it.

## This already affects a migration in this repo

Statement counts for the migrations on `main`, before and after:

| migration | before | after |
|---|---|---|
| `001_initial_schema.sql` | 10 | 10 |
| `002_complete_schema_updates.sql` | **13** | **14** |
| `008_add_animated_background_preference.sql` | 2 | 2 |
| `009_add_ui_theme_preference.sql` | 2 | 2 |
| `010_add_background_theme_preference.sql` | 4 | 4 |

`002` currently has two statements merged into one by an apostrophe in a comment. It runs, for the reason above, but it does not execute in the shape the file describes and an error inside it would be misattributed.

## Changes

- **`scripts/database/sql-statements.js`** (new) — the splitter, moved out of `db-manager.js` verbatim in the first commit so it could be tested at all: `db-manager.js` connects to a database as a side effect of import, so nothing in it was reachable from a test.
- **The fix, in the second commit** — line and block comments are copied through untouched but never interpreted. A string literal containing `--` is still a literal.

Two commits so the extraction is separable from the behaviour change, and both are green.

## Testing

`src/tests/unit/sql-statements.test.js`, 9 tests. Against the unmodified splitter, 4 of them fail:

```
× does not split on a semicolon inside a line comment
  → expected [ …(2) ] to have a length of 1 but got 2
× does not let an apostrophe in a comment swallow the rest of the file
  → expected [ Array(1) ] to have a length of 4 but got 1
× ignores a semicolon inside a block comment
  → expected [ '/* one;', 'two;', …(2) ] to have a length of 2 but got 4
× counts the statements in a migration shaped like a real one
  → expected [ …(2) ] to have a length of 4 but got 2
```

The other 5 pin the behaviour that must not change: ordinary splitting, a semicolon inside a string literal, `--` inside a string literal, a dollar-quoted function body containing semicolons, and comments being retained in the statement they precede.

After the fix: 9/9. Full suite 109 unit and 21 integration, `prettier --check .` clean.

## One thing I did not touch

The `inFunction` heuristic does `remaining.startsWith("create") && remaining.includes("function")`, where `remaining` is the rest of the entire file — so any `CREATE` followed anywhere later by the word "function" sets it, and semicolons are then ignored until a `language` keyword appears. On `001_initial_schema.sql` that happens to work out, and changing it risks the trigger definitions there, so I left it alone rather than bundle a second behaviour change into this PR. Flagging it because it is the same class of bug and the next person to write a migration containing the word "function" in a comment will meet it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
